### PR TITLE
chore: add Docker support and migrate to Bun runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Build outputs (will be built in container)
+node_modules
+dist
+
+# Development files
+.git
+.env*
+.DS_Store
+*.log
+
+# Development tools
+mise.toml
+.husky
+
+# Documentation
+README.md
+CLAUDE.md
+
+# Docker files
+Dockerfile
+.dockerignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,23 @@ jobs:
         env:
           TODOIST_API_TOKEN: test
         run: |
-          timeout 5s node dist/index.js || test $? = 124
+          timeout 5s bun dist/index.js || test $? = 124
           echo "✓ Server starts successfully"
+
+  docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Build Docker image
+        run: docker build -t todoist-mcp-server .
+      - name: Test Docker container
+        env:
+          TODOIST_API_TOKEN: test
+        run: |
+          timeout 5s docker run --rm -e TODOIST_API_TOKEN="$TODOIST_API_TOKEN" todoist-mcp-server || test $? = 124
+          echo "✓ Docker container starts successfully"

--- a/.gitignore
+++ b/.gitignore
@@ -1,35 +1,16 @@
-# dependencies (bun install)
+# Dependencies and build outputs
 node_modules
-
-# output
-out
 dist
-*.tgz
 
-# code coverage
-coverage
-*.lcov
-
-# logs
-logs
-_.log
-report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
-
-# dotenv environment variable files
-.env
-.env.development.local
-.env.test.local
-.env.production.local
-.env.local
+# Environment files
+.env*
 .envrc
 
-# caches
-.eslintcache
-.cache
+# Logs and caches
+*.log
 *.tsbuildinfo
+.cache
 
-# IntelliJ based IDEs
+# IDE and OS files
 .idea
-
-# Finder (MacOS) folder config
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,11 @@ Dockerfile        # Multi-stage Docker build with Bun
 - Test file naming convention: `*.spec.ts`
 - MCP Inspector (`@modelcontextprotocol/inspector`) for visual server testing
 
+**CI/CD**: Comprehensive GitHub Actions workflows
+- **ci.yml**: lint, test, build (with Bun executable test), and Docker container testing
+- **actions-lint.yml**: GitHub Actions workflow validation (actionlint, ghalint, zizmor)
+- All jobs use pinned action versions (managed with pinact) and minimal permissions
+
 **TypeScript**: Configured for modern features with strict checking
 - ES modules with bundler resolution
 - Targets ESNext for Bun runtime compatibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,12 @@ mise install      # Install required tool versions (Bun, Node.js, linting tools)
 
 # Build and run
 bun run build     # Build the MCP server to dist/index.js
-node dist/index.js # Run the built MCP server
+bun dist/index.js # Run the built MCP server
 # or for development: bun run src/index.ts
+
+# Docker
+docker build -t todoist-mcp-server .  # Build Docker image
+docker run -e TODOIST_API_TOKEN=token todoist-mcp-server  # Run in container
 
 # Testing
 bun test          # Run all tests
@@ -59,7 +63,8 @@ src/              # Source code
         └── client.spec.ts # Comprehensive test suite
 scripts/          # Build and utility scripts
 ├── build.ts      # Bun.build configuration
-dist/             # Built output (executable with shebang)
+dist/             # Built output (Bun runtime compatible)
+Dockerfile        # Multi-stage Docker build with Bun
 ```
 
 ## Architecture
@@ -93,14 +98,14 @@ dist/             # Built output (executable with shebang)
 ## Development Tooling
 
 **Tool Version Management**: Uses `mise.toml` for reproducible environments
-- Bun 1.2.15 for development and package management  
-- Node.js 22.16.0 for production runtime
+- Bun 1.2.15 for development, build, and runtime
+- Node.js 22.16.0 (referenced but project uses Bun runtime)
 - Rust 1.87.0 for cargo-based tools
 - GitHub Actions linting tools: actionlint, ghalint (via aqua), zizmor (via cargo)
 
 **Build System**: Custom Bun.build configuration in `scripts/build.ts`
-- Targets Node.js runtime with external packages
-- Adds executable shebang to output
+- Targets Bun runtime with external packages
+- No shebang for Docker compatibility
 - Automatically sets executable permissions via `chmod +x dist/index.js`
 - Cleans and rebuilds to `dist/` directory
 
@@ -133,6 +138,12 @@ dist/             # Built output (executable with shebang)
 - Add comprehensive `.describe()` annotations for all parameters for better UX
 - Include detailed tool descriptions explaining functionality, parameters, and safety warnings
 - Return structured responses with both success messages and complete object data
+
+**Docker Support**: Multi-stage Dockerfile for efficient containerization:
+- Uses official `oven/bun:1.2.15` image for all stages
+- Separates dev/prod dependencies for optimal layer caching
+- Runs as non-root `bun` user for security
+- Requires `TODOIST_API_TOKEN` environment variable
 
 **Extension Strategy**: New features should follow the pattern:
 - Add new files to `src/mcp/resources/` or `src/mcp/tools/` 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# ============================================================================
+# Base stage
+# ============================================================================
+FROM oven/bun:1.2.15 AS base
+WORKDIR /usr/src/app
+
+# ============================================================================
+# Install dependencies stage
+# ============================================================================
+FROM base AS install
+RUN mkdir -p /temp/dev
+COPY package.json bun.lock /temp/dev/
+RUN cd /temp/dev && bun install --frozen-lockfile
+
+# Install production dependencies
+RUN mkdir -p /temp/prod
+COPY package.json bun.lock /temp/prod/
+RUN cd /temp/prod && bun install --frozen-lockfile --production
+
+# ============================================================================
+# Build stage
+# ============================================================================
+FROM base AS build
+COPY --from=install /temp/dev/node_modules node_modules
+COPY . .
+
+ENV NODE_ENV=production
+RUN bun run build
+
+# ============================================================================
+# Release stage
+# ============================================================================
+FROM base AS release
+COPY --from=install /temp/prod/node_modules node_modules
+COPY --from=build /usr/src/app/dist ./dist
+COPY --from=build /usr/src/app/package.json .
+
+# Run as non-root user
+USER bun
+
+# Run the MCP server
+ENTRYPOINT ["bun", "run", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "prepare": "husky",
+    "prepare": "husky || true",
     "build": "bun run scripts/build.ts",
     "lint": "biome check .",
     "format": "biome check --write .",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -9,7 +9,6 @@ await Bun.build({
   outdir: "./dist",
   target: "bun",
   packages: "external",
-  banner: "#!/usr/bin/env bun",
 });
 
 // Make the output file executable

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -7,9 +7,9 @@ await $`rm -rf dist`;
 await Bun.build({
   entrypoints: ["./src/index.ts"],
   outdir: "./dist",
-  target: "node",
+  target: "bun",
   packages: "external",
-  banner: "#!/usr/bin/env node",
+  banner: "#!/usr/bin/env bun",
 });
 
 // Make the output file executable


### PR DESCRIPTION
## Summary

This PR adds comprehensive Docker support and migrates the project runtime from Node.js to Bun for consistency and efficiency.

## Changes Made

### Runtime Migration
- **Migrated build target** from Node.js to Bun in `scripts/build.ts`
- **Removed shebang** from build output to avoid Docker compatibility issues
- **Updated package.json** to handle missing husky gracefully in production environments

### Docker Support
- **Multi-stage Dockerfile** using official `oven/bun:1.2.15` image
  - Install stage: Separates dev and production dependencies for optimal caching
  - Build stage: Compiles TypeScript and builds the application
  - Release stage: Creates minimal production image with only necessary files
- **Security**: Runs as non-root `bun` user
- **Environment**: Requires `TODOIST_API_TOKEN` environment variable

### Configuration Updates
- **Simplified .gitignore** by removing bun init boilerplate and organizing into logical groups
- **Updated .dockerignore** with minimal necessary exclusions
- **Updated CLAUDE.md** to reflect Bun runtime usage and Docker commands

## Docker Usage

```bash
# Build the image
docker build -t todoist-mcp-server .

# Run the container
docker run -e TODOIST_API_TOKEN=your_token todoist-mcp-server
```

## Technical Details

- **Runtime Consistency**: The entire pipeline now uses Bun (development, build, runtime)
- **Optimized Build**: Multi-stage Docker build reduces final image size
- **Layer Caching**: Dependency installation is cached separately from source code changes
- **Environment Validation**: Server validates required environment variables on startup

## Testing

- ✅ Docker build successful
- ✅ Container starts correctly and validates environment variables
- ✅ MCP server initialization works as expected
- ✅ Existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)