### PR TITLE
fix: add multi-platform Docker support for ARM64 and AMD64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -56,6 +58,7 @@ jobs:
       - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add docker/setup-qemu-action for ARM64 emulation support
- Configure build-push-action with platforms: linux/amd64,linux/arm64  
- Enable building Docker images for both x86_64 and ARM64 architectures

## Test plan
- [ ] CI passes (lint, test, build, docker)
- [ ] GitHub Actions workflow validates without errors
- [ ] Multi-platform Docker build configuration is correct

🤖 Generated with [Claude Code](https://claude.ai/code)