### PR TITLE
ci: add TypeScript type checking job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,18 @@ jobs:
       - uses: ./.github/actions/setup
       - run: bun run lint
 
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: bun run typecheck
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ bun test src/lib/todoist/client.spec.ts  # Run specific test file
 # Code quality
 bun run lint      # Check code with Biome
 bun run format    # Format and fix code with Biome
+bun run typecheck # Run TypeScript type checking
 
 # MCP Server Testing
 bun run inspector # Build and launch MCP Inspector for visual testing
@@ -124,7 +125,7 @@ Dockerfile        # Multi-stage Docker build with Bun
 - MCP Inspector (`@modelcontextprotocol/inspector`) for visual server testing
 
 **CI/CD**: Comprehensive GitHub Actions workflows
-- **ci.yml**: lint, test, build (with Bun executable test), and Docker container testing
+- **ci.yml**: lint, typecheck, test, build (with Bun executable test), and Docker container testing
 - **actions-lint.yml**: GitHub Actions workflow validation (actionlint, ghalint, zizmor)
 - **release.yml**: Automated release workflow with release-please and Docker publishing to GHCR
 - **claude.yml**: Claude Code integration workflow triggered by @claude mentions (repository owner only)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "bun run scripts/build.ts",
     "lint": "biome check .",
     "format": "biome check --write .",
+    "typecheck": "tsc --noEmit",
     "preinspector": "bun run build",
     "inspector": "mcp-inspector dist/index.js"
   },


### PR DESCRIPTION
## Summary
- Add TypeScript type checking job to CI workflow
- Add `typecheck` script to package.json using `tsc --noEmit`
- Position typecheck job between lint and test for logical workflow flow

## Test plan
- [x] Verify `bun run typecheck` runs successfully locally
- [ ] Verify typecheck job runs successfully in GitHub Actions CI workflow

🤖 Generated with [Claude Code](https://claude.ai/code)