### PR TITLE
ci: add tool permissions to Claude Code Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,4 +37,5 @@ jobs:
       - uses: anthropics/claude-code-action@47ea5c2a699c59955750d39be0a9ba04bbe9dfb9 # v0.0.15
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "Bash(bun run lint:*),Bash(bun run format:*),Bash(bun run typecheck:*),Bash(bun run build:*),Bash(bun test:*),Bash(zizmor:*),Bash(actionlint:*),Bash(ghalint run:*),Bash(git rebase:*),Bash(pinact:*)"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,7 @@ Dockerfile        # Multi-stage Docker build with Bun
 - Restricted to repository owner only for security
 - Uses anthropic_api_key from GitHub secrets
 - Automatically handles code changes, commits, and PR interactions
+- **Tool Permissions**: Configured with `allowed_tools` for development commands (bun run lint/format/typecheck/build, bun test), GitHub Actions linters (actionlint, ghalint, zizmor), git operations (git rebase), and dependency management (pinact)
 
 **Extension Strategy**: New features should follow the pattern:
 - Add new files to `src/mcp/resources/` or `src/mcp/tools/` 


### PR DESCRIPTION
## Summary
- Add allowed_tools configuration to enable Claude Code Action to use development and CI tools

## Changes
- Add `allowed_tools` parameter to `.github/workflows/claude.yml`
- Enable bun commands, GitHub Actions linters, git operations, and dependency management tools

## Test plan
- [x] Validated workflows with actionlint
- [x] Checked policies with ghalint run  
- [x] Performed security audit with zizmor

🤖 Generated with [Claude Code](https://claude.ai/code)