### PR TITLE
fix: add missing org.opencontainers.image.description label to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY --from=build /usr/src/app/package.json .
 
 # Add OCI source label for better image metadata
 LABEL org.opencontainers.image.source=https://github.com/koki-develop/todoist-mcp-server
+LABEL org.opencontainers.image.description="Todoist MCP server for integrating Todoist with AI assistants through the Model Context Protocol"
 
 # Run as non-root user
 USER bun


### PR DESCRIPTION
## Summary
- Add missing `org.opencontainers.image.description` label to Dockerfile for better Docker image metadata

## Test plan
- [ ] Verify Docker build succeeds
- [ ] Check that the description label is properly set in the built image

🤖 Generated with [Claude Code](https://claude.ai/code)