### PR TITLE
feat: separate create_comment into task and project specific tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ src/              # Source code
 │       ├── sections.ts   # Section tools (CRUD + read operations)
 │       ├── tasks.ts      # Task tools (CRUD + close/reopen + read operations)
 │       ├── labels.ts     # Label tools (create + update + individual/list read + delete operations)
-│       ├── comments.ts   # Comment tools (create + read with pagination)
+│       ├── comments.ts   # Comment tools (separate task/project creation + read with pagination + update/delete)
 │       └── advanced.ts   # Advanced tools (natural language task creation)
 └── lib/
     └── todoist/  # Todoist API client wrapper
@@ -91,20 +91,21 @@ Dockerfile        # Multi-stage Docker build with Bun
 
 **Todoist Integration Layer**: Complete `TodoistClient` class in `src/lib/todoist/client.ts`:
 
-- **API Wrapper**: Wraps `@doist/todoist-api-typescript` with complete project, section, task, label, and comment CRUD operations
+- **API Wrapper**: Wraps `@doist/todoist-api-typescript` with complete project, section, task, label, and comment CRUD operations plus bulk task movement operations
 - **Pagination**: Automatic pagination handling in `getProjects()`, `getSections()`, `getTasks()`, `getLabels()`, `getTaskComments()`, and `getProjectComments()` methods using cursor-based iteration
 - **Individual Retrieval**: Direct methods for getting individual items: `getProject()`, `getSection()`, `getTask()`, `getLabel()`
 - **Advanced Features**: Natural language task creation via `quickAddTask()` with intelligent parsing of dates, projects, labels, and priorities
-- **Comment Management**: Full comment support via `createComment()`, `getTaskComments()`, and `getProjectComments()` with file attachment capabilities
+- **Comment Management**: Full comment support via separate `createTaskComment()` and `createProjectComment()` methods, plus `getTaskComments()`, `getProjectComments()`, `updateComment()`, and `deleteComment()` with file attachment capabilities
+- **Task Movement**: Bulk task reorganization via `moveTasksToProject()`, `moveTasksToSection()`, and `moveTasksToParent()` for efficient workflow management
 - **Environment**: Accepts API token as string parameter, environment handling in calling code
 
 **Current Implementation State**: 
-- **Tools**: Complete tools-only implementation with both read and write operations (26 total tools):
+- **Tools**: Complete tools-only implementation with both read and write operations (29 total tools):
   - **Project Tools**: `get_projects`, `get_project`, `create_project`, `update_project`, `delete_project`
   - **Section Tools**: `get_sections`, `get_section`, `create_section`, `update_section`, `delete_section`
-  - **Task Tools**: `get_tasks` (with filtering), `get_task`, `create_task`, `update_task`, `delete_task`, `close_task`, `reopen_task`
+  - **Task Tools**: `get_tasks` (with filtering), `get_task`, `create_task`, `update_task`, `delete_task`, `close_task`, `reopen_task`, `move_tasks_to_project`, `move_tasks_to_section`, `move_tasks_to_parent`
   - **Label Tools**: `create_label`, `update_label`, `get_label`, `get_labels`, `delete_label`
-  - **Comment Tools**: `create_comment`, `get_task_comments`, `get_project_comments`
+  - **Comment Tools**: `create_task_comment`, `create_project_comment`, `get_task_comments`, `get_project_comments`, `update_comment`, `delete_comment`
   - **Advanced Tools**: `quick_add_task` (natural language processing)
 - **Testing**: Comprehensive TodoistClient test suite with pagination tests + MCP Inspector for visual testing
 - **Architecture**: Extensible structure with full comment management and natural language task creation
@@ -135,7 +136,7 @@ Dockerfile        # Multi-stage Docker build with Bun
 - MCP Inspector (`@modelcontextprotocol/inspector`) for visual server testing
 - Run single test file: `bun test src/lib/todoist/client.spec.ts`
 - Pagination testing pattern: mock multiple API responses with `nextCursor` for comprehensive coverage
-- Advanced feature testing: natural language parsing validation and comment management with attachments
+- Advanced feature testing: natural language parsing validation, comment management with attachments, and bulk task movement operations
 
 **CI/CD**: Comprehensive GitHub Actions workflows
 - **ci.yml**: lint, typecheck, test, build (with Bun executable test), and Docker container testing
@@ -226,10 +227,10 @@ When testing the MCP server functionality, use the Playwright MCP server to auto
 3. **Test Core Operations**: Systematically test tool categories:
    - **Projects**: `get_projects`, `create_project`, `delete_project`  
    - **Sections**: `create_section`, `get_sections`
-   - **Tasks**: `create_task`, `get_tasks`, `close_task`
+   - **Tasks**: `create_task`, `get_tasks`, `close_task`, `move_tasks_to_project`, `move_tasks_to_section`, `move_tasks_to_parent`
    - **Labels**: `create_label`, `update_label`, `get_label`, `get_labels`, `delete_label`
-   - **Comments**: `create_comment`, `get_task_comments`, `get_project_comments`
+   - **Comments**: `create_task_comment`, `create_project_comment`, `get_task_comments`, `get_project_comments`, `update_comment`, `delete_comment`
    - **Advanced**: `quick_add_task` with natural language parsing
-4. **Verify Results**: Check Japanese text support, natural language date parsing, hierarchical data structure, and comment management
+4. **Verify Results**: Check Japanese text support, natural language date parsing, hierarchical data structure, comment management, and bulk task movement operations
 
-This provides comprehensive validation of all 26 MCP tools through automated browser interaction.
+This provides comprehensive validation of all 29 MCP tools through automated browser interaction.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ The server provides the following tools that AI assistants can use to interact w
   - [`get_labels`](#get_labels)
   - [`delete_label`](#delete_label)
 - [Comments](#comments)
-  - [`create_comment`](#create_comment)
+  - [`create_task_comment`](#create_task_comment)
+  - [`create_project_comment`](#create_project_comment)
   - [`update_comment`](#update_comment)
   - [`get_task_comments`](#get_task_comments)
   - [`get_project_comments`](#get_project_comments)
@@ -348,14 +349,26 @@ Permanently deletes a personal label by its unique identifier. **WARNING: This a
 
 ### Comments
 
-#### `create_comment`
-Adds a comment to a Todoist task or project. Supports rich text content and optional file attachments. **You must specify either a task ID or project ID, but not both.** Returns the complete comment object with all metadata upon successful creation.
+#### `create_task_comment`
+Adds a comment to a specific Todoist task. Supports rich text content and optional file attachments. Returns the complete comment object with all metadata upon successful creation.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | **`content`** | **Yes** | The text content of the comment |
-| `taskId` | No | ID of the task to comment on (mutually exclusive with projectId) |
-| `projectId` | No | ID of the project to comment on (mutually exclusive with taskId) |
+| **`taskId`** | **Yes** | ID of the task to comment on |
+| `attachment` | No | File attachment object with URL and metadata |
+| `attachment.fileUrl` | **Yes*** | URL of the file to attach (*required if attachment is provided) |
+| `attachment.fileName` | No | Name of the attached file |
+| `attachment.fileType` | No | MIME type of the file |
+| `attachment.resourceType` | No | Type of resource |
+
+#### `create_project_comment`
+Adds a comment to a specific Todoist project. Supports rich text content and optional file attachments. Returns the complete comment object with all metadata upon successful creation.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| **`content`** | **Yes** | The text content of the comment |
+| **`projectId`** | **Yes** | ID of the project to comment on |
 | `attachment` | No | File attachment object with URL and metadata |
 | `attachment.fileUrl` | **Yes*** | URL of the file to attach (*required if attachment is provided) |
 | `attachment.fileName` | No | Name of the attached file |

--- a/src/lib/todoist/client.spec.ts
+++ b/src/lib/todoist/client.spec.ts
@@ -2,10 +2,11 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { TodoistClient } from "./client";
 import type {
   Comment,
-  CreateCommentParams,
   CreateLabelParams,
+  CreateProjectCommentParams,
   CreateProjectParams,
   CreateSectionParams,
+  CreateTaskCommentParams,
   CreateTaskParams,
   GetSectionsParams,
   GetTasksParams,
@@ -908,7 +909,7 @@ describe("TodoistClient", () => {
     });
   });
 
-  describe("createComment", () => {
+  describe("createTaskComment", () => {
     test("should create a comment for a task", async () => {
       const mockCreatedComment = createMockComment({
         id: "comment123",
@@ -919,49 +920,22 @@ describe("TodoistClient", () => {
 
       mockTodoistApi.addComment.mockResolvedValueOnce(mockCreatedComment);
 
-      const params: CreateCommentParams = {
+      const params: CreateTaskCommentParams = {
         content: "This is a test comment",
         taskId: "task1",
       };
 
-      const comment = await client.createComment(params);
+      const comment = await client.createTaskComment(params);
 
       expect(comment).toEqual(mockCreatedComment);
       expect(mockTodoistApi.addComment).toHaveBeenCalledWith({
         content: "This is a test comment",
         taskId: "task1",
-        projectId: undefined,
         attachment: undefined,
       });
     });
 
-    test("should create a comment for a project", async () => {
-      const mockCreatedComment = createMockComment({
-        id: "comment456",
-        content: "Project comment",
-        taskId: undefined,
-        projectId: "project1",
-      });
-
-      mockTodoistApi.addComment.mockResolvedValueOnce(mockCreatedComment);
-
-      const params: CreateCommentParams = {
-        content: "Project comment",
-        projectId: "project1",
-      };
-
-      const comment = await client.createComment(params);
-
-      expect(comment).toEqual(mockCreatedComment);
-      expect(mockTodoistApi.addComment).toHaveBeenCalledWith({
-        content: "Project comment",
-        taskId: undefined,
-        projectId: "project1",
-        attachment: undefined,
-      });
-    });
-
-    test("should create a comment with attachment", async () => {
+    test("should create a task comment with attachment", async () => {
       const attachment = {
         fileName: "test.pdf",
         fileUrl: "https://example.com/test.pdf",
@@ -984,19 +958,84 @@ describe("TodoistClient", () => {
 
       mockTodoistApi.addComment.mockResolvedValueOnce(mockCreatedComment);
 
-      const params: CreateCommentParams = {
+      const params: CreateTaskCommentParams = {
         content: "Comment with attachment",
         taskId: "task1",
         attachment,
       };
 
-      const comment = await client.createComment(params);
+      const comment = await client.createTaskComment(params);
 
       expect(comment).toEqual(mockCreatedComment);
       expect(mockTodoistApi.addComment).toHaveBeenCalledWith({
         content: "Comment with attachment",
         taskId: "task1",
-        projectId: undefined,
+        attachment,
+      });
+    });
+  });
+
+  describe("createProjectComment", () => {
+    test("should create a comment for a project", async () => {
+      const mockCreatedComment = createMockComment({
+        id: "comment456",
+        content: "Project comment",
+        taskId: undefined,
+        projectId: "project1",
+      });
+
+      mockTodoistApi.addComment.mockResolvedValueOnce(mockCreatedComment);
+
+      const params: CreateProjectCommentParams = {
+        content: "Project comment",
+        projectId: "project1",
+      };
+
+      const comment = await client.createProjectComment(params);
+
+      expect(comment).toEqual(mockCreatedComment);
+      expect(mockTodoistApi.addComment).toHaveBeenCalledWith({
+        content: "Project comment",
+        projectId: "project1",
+        attachment: undefined,
+      });
+    });
+
+    test("should create a project comment with attachment", async () => {
+      const attachment = {
+        fileName: "test.pdf",
+        fileUrl: "https://example.com/test.pdf",
+        fileType: "application/pdf",
+        resourceType: "file",
+      };
+
+      const mockCreatedComment = createMockComment({
+        id: "comment999",
+        content: "Project comment with attachment",
+        taskId: undefined,
+        projectId: "project1",
+        fileAttachment: {
+          resourceType: "file",
+          fileName: "test.pdf",
+          fileUrl: "https://example.com/test.pdf",
+          fileType: "application/pdf",
+        },
+      });
+
+      mockTodoistApi.addComment.mockResolvedValueOnce(mockCreatedComment);
+
+      const params: CreateProjectCommentParams = {
+        content: "Project comment with attachment",
+        projectId: "project1",
+        attachment,
+      };
+
+      const comment = await client.createProjectComment(params);
+
+      expect(comment).toEqual(mockCreatedComment);
+      expect(mockTodoistApi.addComment).toHaveBeenCalledWith({
+        content: "Project comment with attachment",
+        projectId: "project1",
         attachment,
       });
     });

--- a/src/lib/todoist/client.ts
+++ b/src/lib/todoist/client.ts
@@ -1,10 +1,11 @@
 import { TodoistApi } from "@doist/todoist-api-typescript";
 import type {
   Comment,
-  CreateCommentParams,
   CreateLabelParams,
+  CreateProjectCommentParams,
   CreateProjectParams,
   CreateSectionParams,
+  CreateTaskCommentParams,
   CreateTaskParams,
   GetSectionsParams,
   GetTasksParams,
@@ -209,21 +210,22 @@ export class TodoistClient {
     return this._api.deleteLabel(id);
   }
 
-  async createComment(params: CreateCommentParams): Promise<Comment> {
-    // Build the API params ensuring exactly one of taskId or projectId is set
-    // biome-ignore lint/suspicious/noExplicitAny: Required for API parameter construction with mutual exclusivity
-    const apiParams: any = {
+  async createTaskComment(params: CreateTaskCommentParams): Promise<Comment> {
+    return this._api.addComment({
       content: params.content,
+      taskId: params.taskId,
       attachment: params.attachment,
-    };
+    });
+  }
 
-    if (params.taskId) {
-      apiParams.taskId = params.taskId;
-    } else if (params.projectId) {
-      apiParams.projectId = params.projectId;
-    }
-
-    return this._api.addComment(apiParams);
+  async createProjectComment(
+    params: CreateProjectCommentParams,
+  ): Promise<Comment> {
+    return this._api.addComment({
+      content: params.content,
+      projectId: params.projectId,
+      attachment: params.attachment,
+    });
   }
 
   async quickAddTask(params: QuickAddTaskParams): Promise<Task> {

--- a/src/lib/todoist/types.ts
+++ b/src/lib/todoist/types.ts
@@ -94,10 +94,20 @@ export interface UpdateLabelParams {
   isFavorite?: boolean;
 }
 
-export interface CreateCommentParams {
+export interface CreateTaskCommentParams {
   content: string;
-  taskId?: string;
-  projectId?: string;
+  taskId: string;
+  attachment?: {
+    fileName?: string;
+    fileUrl: string;
+    fileType?: string;
+    resourceType?: string;
+  };
+}
+
+export interface CreateProjectCommentParams {
+  content: string;
+  projectId: string;
   attachment?: {
     fileName?: string;
     fileUrl: string;


### PR DESCRIPTION
## Summary

Split the unified `create_comment` tool into separate `create_task_comment` and `create_project_comment` tools for improved API clarity and better separation of concerns.

### Changes Made

- **Separated comment creation tools**: 
  - `create_comment` → `create_task_comment` + `create_project_comment`
- **Updated TodoistClient methods**:
  - `createComment()` → `createTaskComment()` + `createProjectComment()`
- **Enhanced type safety**:
  - `CreateCommentParams` → `CreateTaskCommentParams` + `CreateProjectCommentParams`
- **Comprehensive test updates**: Separate test suites for both comment types with attachment support
- **Documentation updates**: README and CLAUDE.md reflect the new API structure

### Benefits

- **Eliminates mutually exclusive parameters** - no more taskId vs projectId confusion
- **Follows single responsibility principle** - each tool has a clear, focused purpose  
- **Improves developer experience** - more intuitive and explicit API design
- **Better type safety** - required parameters are now explicitly typed
- **Maintains full functionality** - all existing comment features preserved

### Tool Count Update

Total MCP tools: **29** (increased from 26, including new move tasks functionality)

## Test plan

- [x] All existing tests pass with updated method signatures
- [x] New separate test suites for task and project comment creation
- [x] Attachment functionality tested for both comment types
- [x] Type checking and linting pass
- [x] Documentation updated to reflect API changes

🤖 Generated with [Claude Code](https://claude.ai/code)