### PR TITLE
feat: add get_tasks_by_filter tool for advanced task filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,10 +98,10 @@ Dockerfile        # Multi-stage Docker build with Bun
 - **Environment**: Accepts API token as string parameter, environment handling in calling code
 
 **Current Implementation State**: 
-- **Tools**: Complete tools-only implementation with both read and write operations (28 total tools):
+- **Tools**: Complete tools-only implementation with both read and write operations (29 total tools):
   - **Project Tools**: `get_projects`, `get_project`, `create_project`, `update_project`, `delete_project`
   - **Section Tools**: `get_sections`, `get_section`, `create_section`, `update_section`, `delete_section`
-  - **Task Tools**: `get_tasks` (with filtering), `get_task`, `create_task`, `update_task`, `delete_task`, `close_task`, `reopen_task`, `move_tasks_to_project`, `move_tasks_to_section`, `move_tasks_to_parent`
+  - **Task Tools**: `get_tasks` (with filtering), `get_tasks_by_filter` (advanced filter syntax), `get_task`, `create_task`, `update_task`, `delete_task`, `close_task`, `reopen_task`, `move_tasks_to_project`, `move_tasks_to_section`, `move_tasks_to_parent`
   - **Label Tools**: `create_label`, `update_label`, `get_label`, `get_labels`, `delete_label`
   - **Comment Tools**: `create_task_comment`, `create_project_comment`, `get_task_comments`, `get_project_comments`, `update_comment`, `delete_comment`
 - **Testing**: Comprehensive TodoistClient test suite with pagination tests + MCP Inspector for visual testing
@@ -227,9 +227,9 @@ When testing the MCP server functionality, use the Playwright MCP server to auto
 3. **Test Core Operations**: Systematically test tool categories:
    - **Projects**: `get_projects`, `create_project`, `delete_project`  
    - **Sections**: `create_section`, `get_sections`
-   - **Tasks**: `create_task`, `get_tasks`, `close_task`, `move_tasks_to_project`, `move_tasks_to_section`, `move_tasks_to_parent`
+   - **Tasks**: `create_task`, `get_tasks`, `get_tasks_by_filter`, `close_task`, `move_tasks_to_project`, `move_tasks_to_section`, `move_tasks_to_parent`
    - **Labels**: `create_label`, `update_label`, `get_label`, `get_labels`, `delete_label`
    - **Comments**: `create_task_comment`, `create_project_comment`, `get_task_comments`, `get_project_comments`, `update_comment`, `delete_comment`
 4. **Verify Results**: Check Japanese text support, hierarchical data structure, comment management, and bulk task movement operations
 
-This provides comprehensive validation of all 28 MCP tools through automated browser interaction.
+This provides comprehensive validation of all 29 MCP tools through automated browser interaction.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The server provides the following tools that AI assistants can use to interact w
   - [`delete_section`](#delete_section)
 - [Tasks](#tasks)
   - [`get_tasks`](#get_tasks)
+  - [`get_tasks_by_filter`](#get_tasks_by_filter)
   - [`get_task`](#get_task)
   - [`create_task`](#create_task)
   - [`update_task`](#update_task)
@@ -186,6 +187,14 @@ Retrieves Todoist tasks with flexible filtering options. Returns a comprehensive
 | `filter` | No | Custom filter query in Todoist filter syntax |
 | `lang` | No | Language for filter parsing |
 | `ids` | No | Array of specific task IDs to retrieve |
+
+#### `get_tasks_by_filter`
+Retrieves Todoist tasks using advanced filter syntax. Supports powerful filter queries using Todoist's natural language filter syntax for complex task searches. Automatically handles pagination to retrieve all matching tasks.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| **`query`** | **Yes** | Filter query using Todoist's advanced filter syntax. Supports operators: `&` (AND), `\|` (OR), `!` (NOT), `()` (grouping). Filter types include: dates (`today`, `overdue`, `no date`, `7 days`), projects (`#Work`, `##Work` for sub-projects), labels (`@urgent`, `@waiting`), priority (`p1`, `p2`, `p3`, `p4`), assignments (`assigned to: name`), and search (`search: keyword`). Examples: `overdue & @work`, `today \| tomorrow`, `(p1 \| p2) & 7 days`, `#Work & !subtask`, `assigned to: me & @urgent` |
+| `lang` | No | IETF language tag defining what language the filter is written in, if different from default English (e.g., 'ja' for Japanese, 'es' for Spanish) |
 
 #### `get_task`
 Accesses detailed information for a specific Todoist task using its unique identifier. Provides complete task metadata including content, description, project and section assignment, due date information, priority level, assigned labels, completion status, parent-child relationships, and timestamps.

--- a/src/lib/todoist/client.ts
+++ b/src/lib/todoist/client.ts
@@ -20,6 +20,7 @@ import type {
   GetSectionsParams,
   GetTaskCommentsParams,
   GetTaskParams,
+  GetTasksByFilterParams,
   GetTasksParams,
   Label,
   MoveTasksToParentParams,
@@ -89,6 +90,23 @@ export class TodoistClient {
 
     do {
       const response = await this._api.getTasks({ ...params, cursor });
+      tasks.push(...response.results);
+      cursor = response.nextCursor;
+    } while (cursor);
+
+    return tasks;
+  }
+
+  async getTasksByFilter(params: GetTasksByFilterParams): Promise<Task[]> {
+    const tasks: Task[] = [];
+    let cursor: string | null = null;
+
+    do {
+      const response = await this._api.getTasksByFilter({
+        query: params.query,
+        lang: params.lang,
+        cursor,
+      });
       tasks.push(...response.results);
       cursor = response.nextCursor;
     } while (cursor);

--- a/src/lib/todoist/types.ts
+++ b/src/lib/todoist/types.ts
@@ -123,6 +123,21 @@ export const getTasksParamsSchema = z.object({
     .describe("Specific task IDs to retrieve (optional)"),
 });
 
+export const getTasksByFilterParamsSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .describe(
+      "Filter query string using Todoist's advanced filter syntax. Supports operators: `&` (AND), `|` (OR), `!` (NOT), `()` (grouping). Filter types include: dates (`today`, `overdue`, `no date`, `7 days`), projects (`#Work`, `##Work` for sub-projects), labels (`@urgent`, `@waiting`), priority (`p1`, `p2`, `p3`, `p4`), assignments (`assigned to: name`), and search (`search: keyword`). Examples: `overdue & @work`, `today | tomorrow`, `(p1 | p2) & 7 days`, `#Work & !subtask`, `assigned to: me & @urgent`",
+    ),
+  lang: z
+    .string()
+    .optional()
+    .describe(
+      "IETF language tag defining what language the filter is written in, if different from default English (e.g., 'ja' for Japanese, 'es' for Spanish). Optional parameter.",
+    ),
+});
+
 export const createTaskParamsSchema = z.object({
   content: z.string().min(1).describe("Task content"),
   description: z.string().optional().describe("Task description (optional)"),
@@ -323,6 +338,9 @@ export type CreateSectionParams = z.infer<typeof createSectionParamsSchema>;
 export type DeleteSectionParams = z.infer<typeof deleteSectionParamsSchema>;
 export type GetSectionParams = z.infer<typeof getSectionParamsSchema>;
 export type GetTasksParams = z.infer<typeof getTasksParamsSchema>;
+export type GetTasksByFilterParams = z.infer<
+  typeof getTasksByFilterParamsSchema
+>;
 export type CreateTaskParams = z.infer<typeof createTaskParamsSchema>;
 export type DeleteTaskParams = z.infer<typeof deleteTaskParamsSchema>;
 export type GetTaskParams = z.infer<typeof getTaskParamsSchema>;

--- a/src/mcp/tools/tasks.ts
+++ b/src/mcp/tools/tasks.ts
@@ -5,6 +5,7 @@ import {
   createTaskParamsSchema,
   deleteTaskParamsSchema,
   getTaskParamsSchema,
+  getTasksByFilterParamsSchema,
   getTasksParamsSchema,
   moveTasksToParentParamsSchema,
   moveTasksToProjectParamsSchema,
@@ -189,6 +190,32 @@ export function registerTaskTools(server: McpServer, client: TodoistClient) {
           {
             type: "text",
             text: `Retrieved ${tasks.length} task(s)`,
+          },
+          {
+            type: "text",
+            text: JSON.stringify(tasks, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // Get tasks using advanced filter syntax
+  server.tool(
+    "get_tasks_by_filter",
+    "Retrieve Todoist tasks using advanced filter syntax. Supports powerful filter queries using Todoist's natural language filter syntax such as 'overdue & @work', 'today | tomorrow', 'p1 & assigned to: me', etc. This tool leverages Todoist's built-in filtering capabilities for complex task searches. Returns comprehensive task metadata including content, description, project assignment, due dates, priority levels, labels, completion status, and hierarchy information. Automatically handles pagination to retrieve all matching tasks.",
+    getTasksByFilterParamsSchema.shape,
+    async ({ query, lang }) => {
+      const tasks = await client.getTasksByFilter({
+        query,
+        lang,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Retrieved ${tasks.length} task(s) using filter: "${query}"`,
           },
           {
             type: "text",


### PR DESCRIPTION
## Summary
- Implement new `get_tasks_by_filter` MCP tool that leverages Todoist's native filter syntax
- Add comprehensive filter support with automatic pagination
- Update documentation to reflect the new tool (total count: 28 → 29)

## Implementation Details
- **Schema**: Added `getTasksByFilterParamsSchema` with `query` (required) and `lang` (optional) parameters
- **Client**: Implemented `getTasksByFilter` method with automatic pagination following existing patterns
- **MCP Tool**: Registered `get_tasks_by_filter` tool with comprehensive descriptions and examples
- **Filter Syntax**: Supports advanced operators (`&`, `|`, `\!`, `()`) and filter types (dates, projects, labels, priority, assignments)

## Filter Examples
- `overdue & @work` - Overdue tasks with "work" label
- `(p1 | p2) & 7 days` - High priority tasks in next 7 days  
- `#Work & \!subtask` - Work project tasks that aren't subtasks
- `assigned to: me & @urgent` - Urgent tasks assigned to user

## Test Plan
- [x] TypeScript type checking passes
- [x] Linting and formatting passes
- [x] All existing tests continue to pass (45/45)
- [x] Documentation updated (README.md, CLAUDE.md)
- [x] Schema validation and parameter handling verified

🤖 Generated with [Claude Code](https://claude.ai/code)